### PR TITLE
Mark dealloc function as unsafe

### DIFF
--- a/src/alloc.rs
+++ b/src/alloc.rs
@@ -10,9 +10,7 @@ fn alloc(size: usize) -> *mut u8 {
 }
 
 #[no_mangle]
-pub extern "C"
+pub unsafe extern "C"
 fn dealloc(ptr: *mut u8, cap: usize) {
-    unsafe  {
         let _buf = Vec::from_raw_parts(ptr, 0, cap);
-    }
 }


### PR DESCRIPTION
https://github.com/m1el/wasm-asteroids/blob/2bd1d34086aae6580384d64f8b3fa9d19e8ca66a/src/alloc.rs#L13-L18
Hello, it is not a good choice to mark the entire function body as unsafe, which will make the caller ignore the safety requirements that the function parameters must guarantee, the developer who calls the dealloc function may not notice this safety requirement.
The unsafe function called needs to ensure that the parameter must be:
- ptr must have been allocated using the global allocator, such as via the alloc::alloc function.
- T needs to have the same alignment as what ptr was allocated with. (T having a less strict alignment is not sufficient, the alignment really needs to be equal to satisfy the dealloc requirement that memory must be allocated and deallocated with the same layout.)
- The size of T times the capacity (ie. the allocated size in bytes) needs to be the same size as the pointer was allocated with. (Because similar to alignment, dealloc must be called with the same layout size.)
- length needs to be less than or equal to capacity.
- The first length values must be properly initialized values of type T.
- capacity needs to be the capacity that the pointer was allocated with.
- The allocated size in bytes must be no larger than isize::MAX. See the safety documentation of pointer::offset.
[https://doc.rust-lang.org/std/vec/struct.Vec.html#method.from_raw_parts](url)
Marking them unsafe also means that callers must make sure they know what they're doing.